### PR TITLE
Setup a custom RPC service that answers signature requests on network nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4193,6 +4193,7 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "node-template-runtime",
+ "pallet-template-rpc",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
  "pow",
@@ -4245,6 +4246,7 @@ dependencies = [
  "pallet-session",
  "pallet-sudo",
  "pallet-template",
+ "pallet-template-runtime-api",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -4536,6 +4538,25 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+]
+
+[[package]]
+name = "pallet-template-rpc"
+version = "1.0.0"
+dependencies = [
+ "jsonrpsee",
+ "pallet-template-runtime-api",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-template-runtime-api"
+version = "1.0.0"
+dependencies = [
+ "sp-api",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -63,6 +63,7 @@ frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/pari
 
 # Local Dependencies
 node-template-runtime = { version = "4.0.0-dev", path = "../runtime" }
+pallet-template-rpc = { version = "1.0.0", path = "../pallets/template/src/rpc" }
 
 # local packages
 pow = { path = '../consensus/pow' }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -31,22 +31,25 @@ pub fn create_full<C, P>(
 	deps: FullDeps<C, P>,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
 where
-	C: ProvideRuntimeApi<Block>,
-	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + 'static,
-	C: Send + Sync + 'static,
-	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
-	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
-	C::Api: BlockBuilder<Block>,
-	P: TransactionPool + 'static,
+C: ProvideRuntimeApi<Block>,
+C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + 'static,
+C: Send + Sync + 'static,
+C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
+C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+C::Api: pallet_template_rpc::TemplateRuntimeApi<Block>,
+C::Api: BlockBuilder<Block>,
+P: TransactionPool + 'static,
 {
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
 	use substrate_frame_rpc_system::{System, SystemApiServer};
+	use pallet_template_rpc::{TemplatePallet, TemplateApiServer};
 
 	let mut module = RpcModule::new(());
 	let FullDeps { client, pool, deny_unsafe } = deps;
 
 	module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
-	module.merge(TransactionPayment::new(client).into_rpc())?;
+	module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
+	module.merge(TemplatePallet::new(client).into_rpc())?;
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed

--- a/pallets/template/src/lib.rs
+++ b/pallets/template/src/lib.rs
@@ -32,7 +32,7 @@ pub mod pallet {
 	// The pallet's runtime storage items.
 	// https://docs.substrate.io/main-docs/build/runtime-storage/
 	#[pallet::storage]
-	#[pallet::getter(fn something)]
+	#[pallet::getter(fn get_value)]
 	// Learn more about declaring storage items:
 	// https://docs.substrate.io/main-docs/build/runtime-storage/#declaring-storage-items
 	pub type Something<T> = StorageValue<_, u32>;

--- a/pallets/template/src/rpc/Cargo.toml
+++ b/pallets/template/src/rpc/Cargo.toml
@@ -18,9 +18,9 @@ jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 
 # Substrate packages
 
-sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
-sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
-sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
 
 # local packages
 pallet-template-runtime-api = { path = "./runtime-api", default-features = false }

--- a/pallets/template/src/rpc/Cargo.toml
+++ b/pallets/template/src/rpc/Cargo.toml
@@ -13,7 +13,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
     "derive",
 ] }
 
-jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
+jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
 
 
 # Substrate packages

--- a/pallets/template/src/rpc/Cargo.toml
+++ b/pallets/template/src/rpc/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "pallet-template-rpc"
+version = "1.0.0"
+edition = "2021"
+authors = ["Alex Bean <https://github.com/AlexD10S>"]
+description = 'RPC methods for the template pallet'
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+    "derive",
+] }
+
+jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
+
+
+# Substrate packages
+
+sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
+sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
+sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
+
+# local packages
+pallet-template-runtime-api = { path = "./runtime-api", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+  "sp-api/std",
+  "sp-runtime/std",
+  "pallet-template-runtime-api/std"
+]

--- a/pallets/template/src/rpc/runtime-api/Cargo.toml
+++ b/pallets/template/src/rpc/runtime-api/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pallet-template-runtime-api"
+authors = ["Alex Bean <https://github.com/AlexD10S>"]
+version = "1.0.0"
+edition = "2021"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "sp-api/std",
+]

--- a/pallets/template/src/rpc/runtime-api/Cargo.toml
+++ b/pallets/template/src/rpc/runtime-api/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28", default-features = false }
+sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
 
 [features]
 default = ["std"]

--- a/pallets/template/src/rpc/runtime-api/src/lib.rs
+++ b/pallets/template/src/rpc/runtime-api/src/lib.rs
@@ -1,0 +1,9 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+// Here we declare the runtime API. It is implemented it the `impl` block in
+// runtime file (the `runtime/src/lib.rs`)
+sp_api::decl_runtime_apis! {
+	pub trait TemplateApi {
+		fn get_value() -> u32;
+	}
+}

--- a/pallets/template/src/rpc/src/lib.rs
+++ b/pallets/template/src/rpc/src/lib.rs
@@ -38,9 +38,10 @@ C::Api: TemplateRuntimeApi<Block>,
 {
 	fn get_value(&self, at: Option<<Block as BlockT>::Hash>) -> RpcResult<u32> {
 		let api = self.client.runtime_api();
-		let at = BlockId::hash(at.unwrap_or_else(||self.client.info().best_hash));
+		// let at = BlockId::hash(at.unwrap_or_else(||self.client.info().best_hash));
+		let at = at.unwrap_or_else(||self.client.info().best_hash);
 
-		api.get_value(&at).map_err(runtime_error_into_rpc_err)
+		api.get_value(at).map_err(runtime_error_into_rpc_err)
 	}
 }
 

--- a/pallets/template/src/rpc/src/lib.rs
+++ b/pallets/template/src/rpc/src/lib.rs
@@ -1,0 +1,57 @@
+pub use pallet_template_runtime_api::TemplateApi as TemplateRuntimeApi;
+use jsonrpsee::{
+	core::{Error as JsonRpseeError, RpcResult},
+	proc_macros::rpc,
+	types::error::{CallError, ErrorObject},
+};
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::HeaderBackend;
+use sp_runtime::{generic::BlockId, traits::Block as BlockT};
+use std::sync::Arc;
+
+#[rpc(client, server)]
+pub trait TemplateApi<BlockHash> {
+	#[method(name = "template_getValue")]
+	fn get_value(&self, at: Option<BlockHash>) -> RpcResult<u32>;
+}
+
+/// A struct that implements the `TemplateApi`.
+pub struct TemplatePallet<C, Block> {
+	// If you have more generics, no need to TemplatePallet<C, M, N, P, ...>
+	// just use a tuple like TemplatePallet<C, (M, N, P, ...)>
+	client: Arc<C>,
+	_marker: std::marker::PhantomData<Block>,
+}
+
+impl<C, Block> TemplatePallet<C, Block> {
+	/// Create new `TemplatePallet` instance with the given reference to the client.
+	pub fn new(client: Arc<C>) -> Self {
+		Self { client, _marker: Default::default() }
+	}
+}
+
+impl<C, Block> TemplateApiServer<<Block as BlockT>::Hash> for TemplatePallet<C, Block>
+where
+Block: BlockT,
+C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
+C::Api: TemplateRuntimeApi<Block>,
+{
+	fn get_value(&self, at: Option<<Block as BlockT>::Hash>) -> RpcResult<u32> {
+		let api = self.client.runtime_api();
+		let at = BlockId::hash(at.unwrap_or_else(||self.client.info().best_hash));
+
+		api.get_value(&at).map_err(runtime_error_into_rpc_err)
+	}
+}
+
+const RUNTIME_ERROR: i32 = 1;
+
+/// Converts a runtime trap into an RPC error.
+fn runtime_error_into_rpc_err(err: impl std::fmt::Debug) -> JsonRpseeError {
+	CallError::Custom(ErrorObject::owned(
+		RUNTIME_ERROR,
+		"Runtime error",
+		Some(format!("{:?}", err)),
+	))
+	.into()
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -48,6 +48,7 @@ frame-system-benchmarking = { version = "4.0.0-dev", default-features = false, g
 
 # Local Dependencies
 pallet-template = { version = "4.0.0-dev", default-features = false, path = "../pallets/template" }
+pallet-template-runtime-api = { path = "../pallets/template/src/rpc/runtime-api", default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/paritytech/substrate.git", optional = true , branch = "polkadot-v0.9.40" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -533,6 +533,12 @@ impl_runtime_apis! {
 			Executive::try_execute_block(block, state_root_check, signature_check, select).expect("execute-block failed")
 		}
 	}
+
+	impl pallet_template_runtime_api::TemplateApi<Block> for Runtime {
+		fn get_value() -> u32 {
+			TemplateModule::get_value().unwrap_or(0)
+		}
+	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
These changes add a custom RPC service. It is a very simple sample taken from a tutorial for now, but we should enhance it so that it can actually sign things.

To test it, use ``curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "template_getValue"}' http://localhost:9933/`` while the node is running.