### PR TITLE
Make the keystore available in the signing rpc pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4549,6 +4549,8 @@ dependencies = [
  "parity-scale-codec",
  "sp-api",
  "sp-blockchain",
+ "sp-core",
+ "sp-keystore",
  "sp-runtime",
 ]
 

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -15,6 +15,7 @@ use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 
 pub use sc_rpc_api::DenyUnsafe;
+use sp_keystore::SyncCryptoStorePtr;
 
 /// Full client dependencies.
 pub struct FullDeps<C, P> {
@@ -24,6 +25,8 @@ pub struct FullDeps<C, P> {
 	pub pool: Arc<P>,
 	/// Whether to deny unsafe calls
 	pub deny_unsafe: DenyUnsafe,
+	/// Keystore
+	pub keystore: SyncCryptoStorePtr
 }
 
 /// Instantiate all full RPC extensions.
@@ -45,11 +48,11 @@ P: TransactionPool + 'static,
 	use pallet_template_rpc::{TemplatePallet, TemplateApiServer};
 
 	let mut module = RpcModule::new(());
-	let FullDeps { client, pool, deny_unsafe } = deps;
+	let FullDeps { client, pool, deny_unsafe, keystore } = deps;
 
 	module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
 	module.merge(TransactionPayment::new(client.clone()).into_rpc())?;
-	module.merge(TemplatePallet::new(client).into_rpc())?;
+	module.merge(TemplatePallet::new(client, keystore).into_rpc())?;
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -217,10 +217,11 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
 	let rpc_extensions_builder = {
 		let client = client.clone();
 		let pool = transaction_pool.clone();
+		let keystore = keystore_container.sync_keystore();
 
 		Box::new(move |deny_unsafe, _| {
 			let deps =
-				crate::rpc::FullDeps { client: client.clone(), pool: pool.clone(), deny_unsafe };
+				crate::rpc::FullDeps { client: client.clone(), pool: pool.clone(), deny_unsafe, keystore: keystore.clone() };
 			crate::rpc::create_full(deps).map_err(Into::into)
 		})
 	};
@@ -304,7 +305,7 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
 		.iter()
 		.map(|k| sr25519::Public::from(k.clone()))
 		.collect();
-		
+
 		// Use authority-discovery session key to sign a message (should use a different ECDSA session key KEY_TYPE instead)
 		let signature = SyncCryptoStore::sign_with(
 			&*keystore_container.sync_keystore(),

--- a/pallets/template/src/rpc/Cargo.toml
+++ b/pallets/template/src/rpc/Cargo.toml
@@ -21,6 +21,8 @@ jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
 sp-api = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
 sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
 sp-runtime = { version = "7.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+sp-keystore = { version = "0.13.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+sp-core = { version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
 
 # local packages
 pallet-template-runtime-api = { path = "./runtime-api", default-features = false }

--- a/pallets/template/src/rpc/src/lib.rs
+++ b/pallets/template/src/rpc/src/lib.rs
@@ -8,11 +8,17 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use std::sync::Arc;
+use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
+use sp_core::{sr25519, H512};
+use sp_runtime::{key_types::AUTHORITY_DISCOVERY as AUTHORITY_DISCOVERY_KEY_TYPE};
 
 #[rpc(client, server)]
 pub trait TemplateApi<BlockHash> {
 	#[method(name = "template_getValue")]
 	fn get_value(&self, at: Option<BlockHash>) -> RpcResult<u32>;
+
+	#[method(name = "sign")]
+	fn sign(&self, msg: String) -> RpcResult<String>;
 }
 
 /// A struct that implements the `TemplateApi`.
@@ -20,13 +26,14 @@ pub struct TemplatePallet<C, Block> {
 	// If you have more generics, no need to TemplatePallet<C, M, N, P, ...>
 	// just use a tuple like TemplatePallet<C, (M, N, P, ...)>
 	client: Arc<C>,
+	keystore: SyncCryptoStorePtr,
 	_marker: std::marker::PhantomData<Block>,
 }
 
 impl<C, Block> TemplatePallet<C, Block> {
 	/// Create new `TemplatePallet` instance with the given reference to the client.
-	pub fn new(client: Arc<C>) -> Self {
-		Self { client, _marker: Default::default() }
+	pub fn new(client: Arc<C>, keystore: SyncCryptoStorePtr) -> Self {
+		Self { client, keystore, _marker: Default::default() }
 	}
 }
 
@@ -42,6 +49,34 @@ C::Api: TemplateRuntimeApi<Block>,
 		let at = at.unwrap_or_else(||self.client.info().best_hash);
 
 		api.get_value(at).map_err(runtime_error_into_rpc_err)
+	}
+
+	fn sign(&self, msg: String) -> RpcResult<String> {
+		// Get node authority-discovery public session key from keystore
+		let authority_discovery_pubkey: Vec<sr25519::Public> = SyncCryptoStore::sr25519_public_keys(
+			&*self.keystore,
+			AUTHORITY_DISCOVERY_KEY_TYPE,
+		)
+		.iter()
+		.map(|k| sr25519::Public::from(k.clone()))
+		.collect();
+
+		if authority_discovery_pubkey.is_empty(){
+			return Err(runtime_error_into_rpc_err("The list of public keys is empty"))
+		}
+
+		// Use authority-discovery session key to sign a message (should use a different ECDSA session key KEY_TYPE instead)
+		let signature = SyncCryptoStore::sign_with(
+			&*self.keystore,
+			AUTHORITY_DISCOVERY_KEY_TYPE,
+			&authority_discovery_pubkey[0].into(),
+			msg.as_bytes()
+		).map_err(runtime_error_into_rpc_err);
+
+		match signature {
+			Ok(Some(sig)) => Ok(std::format!("{:?}", H512::from_slice(&sig))),
+			_ => Err(runtime_error_into_rpc_err("Couldn't sign message"))
+		}
 	}
 }
 


### PR DESCRIPTION
These changes make the keystore available in the RPC pallet. In addition, it adds the ``sign`` endpoint to sign things using the authority key. To test it, use ``curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "sign", "params": ["any message"]}' http://localhost:9933/``

This PR depends on https://github.com/ambula-labs/ambula/pull/22.